### PR TITLE
Problem035

### DIFF
--- a/problems/035/main.go
+++ b/problems/035/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// 循環素数
+// 1. 1000000までを回す
+// 2. 循環素数であれば配列に追加
+func main() {
+	// 上限
+	const LIMIT int = 1000000
+	// 素数配列
+	primeNumbers := []int{}
+	// 上限までループ処理
+	for i := 2; i < LIMIT; i++ {
+		if isCircularPrimeNumber(i) {
+			primeNumbers = append(primeNumbers, i)
+		}
+	}
+	fmt.Println(len(primeNumbers))
+}
+
+// 素数判定(割り切れる場合をTRUE)
+func isPrimeNumber(num int) bool {
+	x := 2
+	for x*x <= num {
+		if num%x == 0 {
+			return false
+		}
+		x++
+	}
+	return true
+}
+
+// 循環素数判定(引数は素数のみを受け付ける想定、割り切れる場合をTRUEで返却)
+func isCircularPrimeNumber(num int) bool {
+	arr := strings.Split(strconv.Itoa(num), "")
+	for i := range arr {
+		rotated := append(arr[i:], arr[:i]...)
+		rotatedNumber, _ := strconv.Atoi(strings.Join(rotated, ""))
+		if !isPrimeNumber(rotatedNumber) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## 問題
### [Circular Primes](https://projecteuler.net/problem=35)
数 $197$ は「巡回素数」と呼ばれます。なぜなら、その桁のすべての回転: $197$, $971$, および $719$ がすべて素数であるからです。
$100$ 未満には、このような巡回素数が $13$ 個あります: $2, 3, 5, 7, 11, 13, 17, 31, 37, 71, 73, 79$, および $97$。
$1,000,000$ 未満には、いくつの巡回素数があるでしょうか？


## 処理速度
0.318s

## GPT-4.1の回答
```go
package main

import (
	"fmt"
	"math"
	"strconv"
)

// 素数判定
func isPrime(n int) bool {
	if n < 2 {
		return false
	}
	if n == 2 {
		return true
	}
	if n%2 == 0 {
		return false
	}
	sqrt := int(math.Sqrt(float64(n)))
	for i := 3; i <= sqrt; i += 2 {
		if n%i == 0 {
			return false
		}
	}
	return true
}

// 桁を回転した値をすべて取得
func rotations(n int) []int {
	s := strconv.Itoa(n)
	var rots []int
	for i := 0; i < len(s); i++ {
		rot, _ := strconv.Atoi(s[i:] + s[:i])
		rots = append(rots, rot)
	}
	return rots
}

// 巡回素数かどうか判定
func isCircularPrime(n int) bool {
	for _, rot := range rotations(n) {
		if !isPrime(rot) {
			return false
		}
	}
	return true
}

func main() {
	const limit = 1000000
	count := 0

	for i := 2; i < limit; i++ {
		if isCircularPrime(i) {
			count++
		}
	}

	fmt.Println(count)
}
```

## Gemini2.5 Flashの回答
```go
package main

import (
	"fmt"
	"strconv"
)

const limit = 1000000

var primes [limit]bool
var isCircular map[int]bool

func sieveOfEratosthenes() {
	for i := 0; i < limit; i++ {
		primes[i] = true
	}
	primes[0] = false
	primes[1] = false
	for p := 2; p*p < limit; p++ {
		if primes[p] {
			for i := p * p; i < limit; i += p {
				primes[i] = false
			}
		}
	}
}

func getRotations(n int) []int {
	s := strconv.Itoa(n)
	rotations := []int{}
	for i := 0; i < len(s); i++ {
		rotatedStr := s[i:] + s[:i]
		rotatedInt, _ := strconv.Atoi(rotatedStr)
		rotations = append(rotations, rotatedInt)
	}
	return rotations
}

func isAllRotationsPrime(n int) bool {
	if isCircular[n] { // Already checked and found to be circular
		return true
	}
	if !primes[n] {
		return false
	}

	rotations := getRotations(n)
	for _, r := range rotations {
		if !primes[r] {
			return false
		}
	}
	return true
}

func main() {
	sieveOfEratosthenes()
	isCircular = make(map[int]bool)
	count := 0

	for i := 2; i < limit; i++ {
		if primes[i] && !isCircular[i] { // Only check if it's a prime and not already processed as circular
			if isAllRotationsPrime(i) {
				count++
				// Mark all rotations as circular to avoid redundant checks
				for _, r := range getRotations(i) {
					isCircular[r] = true
				}
			}
		}
	}

	fmt.Println("1,000,000 未満の巡回素数の数:", count)
}
```
