### PR TITLE
Problem019

### DIFF
--- a/problems/019/main.go
+++ b/problems/019/main.go
@@ -1,0 +1,57 @@
+package main
+
+import "fmt"
+
+// 20 世紀 (1901 年 1 月 1 日から 2000 年 12 月 31 日) に、月の 1 日が日曜日だった日は何日ありましたか?
+func main() {
+	// それぞれの月の日数を格納
+	var days = (map[int]int{
+		1:  31,
+		2:  28,
+		3:  31,
+		4:  30,
+		5:  31,
+		6:  30,
+		7:  31,
+		8:  31,
+		9:  30,
+		10: 31,
+		11: 30,
+		12: 31,
+	})
+
+	// 1901/01/01は月曜日スタート、曜日を変数で管理
+	current := 2
+	// 日曜日だった数
+	count := 0
+	for year := 1901; year <= 2000; year++ {
+		for month := 1; month <= 12; month++ {
+			lastDay := days[month]
+			if month == 2 && isLeapYear(year) {
+				lastDay++
+			}
+			current = getNextStartDay(current, lastDay)
+			current++
+			if current%7 == 0 {
+				count++
+			}
+		}
+	}
+	if current%7 == 0 {
+		count--
+	}
+	fmt.Println(count)
+}
+
+// 閏年
+func isLeapYear(year int) bool {
+	if year%400 == 0 {
+		return false
+	}
+	return year%4 == 0
+}
+
+// 　来月のスタートが何曜日かを返す関数
+func getNextStartDay(current int, lastDay int) int {
+	return (((lastDay - 1) + current) % 7)
+}


### PR DESCRIPTION
## 問題
### [Counting Sundays](https://projecteuler.net/problem=19)
20 世紀 (1901 年 1 月 1 日から 2000 年 12 月 31 日) に、月の 1 日が日曜日だった日は何日ありましたか?

## 処理速度
0.141s

## GPT-4.1の回答
```go
func main() {
    count := 0
    loc := time.UTC
    for year := 1901; year <= 2000; year++ {
        for month := time.January; month <= time.December; month++ {
            t := time.Date(year, month, 1, 0, 0, 0, 0, loc)
            if t.Weekday() == time.Sunday {
                count++
            }
        }
    }
    fmt.Println(count) // 出力: 171
}
```

## Gemini2.5 Flashの回答
```go
// isLeapYear checks if a given year is a leap year.
func isLeapYear(year int) bool {
	if year%400 == 0 {
		return true
	}
	if year%100 == 0 {
		return false
	}
	if year%4 == 0 {
		return true
	}
	return false
}

// daysInMonth returns the number of days in a given month and year.
func daysInMonth(month, year int) int {
	switch month {
	case 4, 6, 9, 11: // April, June, September, November
		return 30
	case 2: // February
		if isLeapYear(year) {
			return 29
		}
		return 28
	default: // All other months
		return 31
	}
}

func main() {
	// 1 Jan 1900 was a Monday.
	// We need to find Sundays that fell on the first of the month
	// during the twentieth century (1 Jan 1901 to 31 Dec 2000).

	// daysSince1Jan1900 will keep track of the total number of days
	// passed since 1 Jan 1900.
	daysSince1Jan1900 := 0

	// Initialize the count of Sundays on the first of the month.
	sundayFirstOfMonthCount := 0

	// Calculate days in 1900 to set the starting day for 1 Jan 1901
	for month := 1; month <= 12; month++ {
		daysSince1Jan1900 += daysInMonth(month, 1900)
	}

	// Iterate through the twentieth century (1 Jan 1901 to 31 Dec 2000)
	for year := 1901; year <= 2000; year++ {
		for month := 1; month <= 12; month++ {
			// Check if the first of the current month is a Sunday.
			// 1 Jan 1900 was a Monday (day 1 of the week if Sunday is 0).
			// So, (daysSince1Jan1900 % 7) will give the day of the week
			// where 0 = Monday, 1 = Tuesday, ..., 6 = Sunday.
			// We are looking for Sunday, which corresponds to a remainder of 6.
			if (daysSince1Jan1900 % 7) == 6 {
				sundayFirstOfMonthCount++
			}

			// Add the number of days in the current month to the total.
			daysSince1Jan1900 += daysInMonth(month, year)
		}
	}

	fmt.Println(sundayFirstOfMonthCount)
}
```
