### PR TITLE
Problem028

### DIFF
--- a/problems/028/main.go
+++ b/problems/028/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	solve()
+}
+
+func solve() {
+	count := 2
+	sum := 1
+	// 1ループ増えるごとに+2ずつ加算される
+	roopCount := 0
+	for count <= 1001*1001 {
+		for i := 0; i < 4; i++ {
+			count += getAdvanceNum(i, roopCount)
+			sum += count
+			// 4つ目の角の場合は-1をする
+			if i == 3 {
+				sum--
+			}
+		}
+		roopCount = roopCount + 2
+	}
+	fmt.Println(sum)
+}
+
+// スパイラルの向きに応じて進める数を取得
+func getAdvanceNum(num int, roopCount int) int {
+	mapping := map[int]int{
+		0: 1,
+		1: 2,
+		2: 2,
+		3: 3,
+	}
+	return mapping[num] + roopCount
+}

--- a/problems/028/main_test.go
+++ b/problems/028/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSolve(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solve()
+	}
+}


### PR DESCRIPTION
## 問題
### [Number Spiral Diagonals](https://projecteuler.net/problem=28)
<p>Starting with the number $1$ and moving to the right in a clockwise direction a $5$ by $5$ spiral is formed as follows:</p>
<p class="monospace center"><span class="red"><b>21</b></span> 22 23 24 <span class="red"><b>25</b></span><br>
20  <span class="red"><b>7</b></span>  8  <span class="red"><b>9</b></span> 10<br>
19  6  <span class="red"><b>1</b></span>  2 11<br>
18  <span class="red"><b>5</b></span>  4  <span class="red"><b>3</b></span> 12<br><span class="red"><b>17</b></span> 16 15 14 <span class="red"><b>13</b></span></p>
<p>It can be verified that the sum of the numbers on the diagonals is $101$.</p>
<p>What is the sum of the numbers on the diagonals in a $1001$ by $1001$ spiral formed in the same way?</p>

## 処理速度

| 計測        | 実行回数 (b.N) | 平均実行時間 (ns/op) |
| --------- | ---------- | -------------- |
| わたしの回答    | 19,041     | 63,291 ns/op   |
| GPT4.1    | 662,234    | 1,775 ns/op    |
| Gemini2.5 | 489,642    | 2,491 ns/op    |


## GPT-4.1の回答
```go
func solve() {
	size := 1001
	sum := 1 // 中心の1を初期値とする

	for l := 3; l <= size; l += 2 {
		// l: 各層の1辺の長さ（3, 5, ..., 1001）
		sq := l * l
		// 4隅の値を加算
		sum += sq           // 右下
		sum += sq - (l - 1) // 左下
		sum += sq - 2*(l-1) // 左上
		sum += sq - 3*(l-1) // 右上
	}
	fmt.Println(sum)
}

```

## Gemini2.5 Flashの回答
```go
func solve() {
	// 螺旋のサイズ
	const gridSize = 1001

	// 合計を格納する変数。中心の'1'で初期化。
	// 数値が大きくなる可能性があるため、int64を使用する。
	var sum int64 = 1

	// 3x3から1001x1001までの各層をループする
	for s := 3; s <= gridSize; s += 2 {
		// int64にキャストして計算を行う
		s64 := int64(s)

		// 現在の層の4つの角の値を合計に加算する
		// 4つの角の値の合計は 4*s^2 - 6*(s-1) で表せる
		layerSum := 4*s64*s64 - 6*(s64-1)
		sum += layerSum
	}

	// 結果を出力
	fmt.Printf("A %d x %d spiralの対角線上の数字の合計は: %d\n", gridSize, gridSize, sum)
}
```
