### PR TITLE
Problem036

### DIFF
--- a/problems/036/main.go
+++ b/problems/036/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	solve()
+}
+
+func solve() {
+	sum := 0
+	for i := 1; i < 1000000; i++ {
+		if isFrequency(strconv.Itoa(i)) && isFrequency(strconv.FormatInt(int64(i), 2)) {
+			sum += i
+		}
+	}
+	fmt.Println(sum)
+}
+
+// 回文数判定
+func isFrequency(s string) bool {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes) == s
+}

--- a/problems/036/main_test.go
+++ b/problems/036/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSolve(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solve()
+	}
+}


### PR DESCRIPTION
## 問題
### [Double-base Palindromes](https://projecteuler.net/problem=36)
<p>The decimal number, $585 = 1001001001_2$ (binary), is palindromic in both bases.</p>
<p>Find the sum of all numbers, less than one million, which are palindromic in base $10$ and base $2$.</p>
<p class="smaller">(Please note that the palindromic number, in either base, may not include leading zeros.)</p>


## 処理速度

| 計測        | 実行回数 (b.N) | 平均実行時間 (ns/op)   |
| --------- | ---------- | ---------------- |
| わたしの回答    | 22         | 53,173,515 ns/op |
| GPT4.1    | 30         | 40,046,885 ns/op |
| Gemini2.5 | 68         | 17283409 ns/op   |


## GPT-4.1の回答
```go
// 回文判定関数
func isPalindrome(s string) bool {
	n := len(s)
	for i := 0; i < n/2; i++ {
		if s[i] != s[n-1-i] {
			return false
		}
	}
	return true
}

func solve() {
	sum := 0
	for i := 1; i < 1000000; i++ {
		dec := strconv.Itoa(i)
		bin := strconv.FormatInt(int64(i), 2)

		if isPalindrome(dec) && isPalindrome(bin) {
			sum += i
		}
	}
	fmt.Println(sum)
}

```

## Gemini2.5 Proの回答
```go
func isPalindrome(s string) bool {
	length := len(s)
	for i := 0; i < length/2; i++ {
		if s[i] != s[length-1-i] {
			return false
		}
	}
	return true
}

func solve() {
	totalSum := 0
	limit := 1000000

	for i := 1; i < limit; i++ {
		base10Str := strconv.Itoa(i)
		if isPalindrome(base10Str) {
			base2Str := fmt.Sprintf("%b", i)
			if isPalindrome(base2Str) {
				totalSum += i
			}
		}
	}
	fmt.Printf("100万未満で10進数と2進数の両方で回文数となるすべての数の合計は: %d\n", totalSum)
}```
