### PR TITLE
Problem048

### DIFF
--- a/problems/048/main.go
+++ b/problems/048/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"math/big"
+)
+
+func main() {
+	solve()
+}
+
+func solve() {
+	result := big.NewInt(0)
+	for i := 1; i < 1000; i++ {
+		x := big.NewInt(1)
+		for j := 1; j <= i; j++ {
+			x = x.Mul(x, big.NewInt(int64(i)))
+		}
+		result = result.Add(result, x)
+	}
+	fmt.Println(result.Text(10)[len(result.Text(10))-10:])
+}

--- a/problems/048/main_test.go
+++ b/problems/048/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSolve(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solve()
+	}
+}


### PR DESCRIPTION
## 問題
### [Self Powers](https://projecteuler.net/problem=48)
The series, $1^1 + 2^2 + 3^3 + \cdots + 10^{10} = 10405071317$.

Find the last ten digits of the series, $1^1 + 2^2 + 3^3 + \cdots + 1000^{1000}$.

## 処理速度

| 計測        | 実行回数 (b.N) | 平均実行時間 (ns/op)   |
| --------- | ---------- | ---------------- |
| わたしの回答    | 82         | 13,609,246 ns/op |
| GPT4.1    | 584        | 2,014,972 ns/op  |
| Gemini2.5 | 3662       | 317,416 ns/op    |


## GPT-4.1の回答
```go
func solve() {
	const mod = 10000000000
	sum := 0
	for i := 1; i <= 1000; i++ {
		tmp := 1
		for j := 0; j < i; j++ {
			tmp = (tmp * i) % mod
		}
		sum = (sum + tmp) % mod
	}

	fmt.Printf("%010d\n", sum) // 下10桁、ゼロ埋め
}
```

## Gemini2.5 Flashの回答
```go
func solve() {
	modulus := new(big.Int).Exp(big.NewInt(10), big.NewInt(10), nil)
	totalSum := big.NewInt(0)

	for n := int64(1); n <= 1000; n++ {
		if n%10 == 0 {
			continue
		}
		base := big.NewInt(n)
		exponent := big.NewInt(n)
		term := new(big.Int).Exp(base, exponent, modulus)
		totalSum.Add(totalSum, term)
		totalSum.Mod(totalSum, modulus)
	}
	result := fmt.Sprintf("%010s", totalSum.String())

	fmt.Println("級数 1^1 + 2^2 + ... + 1000^1000 の下10桁は以下の通りです。")
	fmt.Println(result)
}
```
