### PR TITLE
Problem055

### DIFF
--- a/problems/055/main.go
+++ b/problems/055/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	solve()
+}
+
+func solve() {
+	count := 0
+	for i := 11; i <= 10000; i++ {
+		if isLychrelNumber(i) {
+			count++
+		}
+	}
+	fmt.Println(count)
+}
+
+// 受け取った数字を前後入れ替えて和を求める
+// その和が回分数かを確認する
+func isLychrelNumber(num int) bool {
+	for i := 1; i <= 50; i++ {
+		reverseNum, _ := strconv.Atoi(reverseString(strconv.Itoa(num)))
+		// 元の数字と入れ替えた数字を足す
+		num += reverseNum
+		// 和が回分数かチェックする
+		reverseSum, _ := strconv.Atoi(reverseString(strconv.Itoa(num)))
+		if num == reverseSum {
+			return false
+		}
+	}
+	return true
+}
+
+// 順番を入れ替える
+func reverseString(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}

--- a/problems/055/main_test.go
+++ b/problems/055/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSolve(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solve()
+	}
+}


### PR DESCRIPTION
## 問題
### [Lychrel Numbers](https://projecteuler.net/problem=55)
If we take $47$, reverse and add, $47 + 74 = 121$, which is palindromic.
Not all numbers produce palindromes so quickly. For example,
\begin{align}
349 + 943 &amp;= 1292\\
1292 + 2921 &amp;= 4213\\
4213 + 3124 &amp;= 7337
\end{align}
That is, $349$ took three iterations to arrive at a palindrome.
Although no one has proved it yet, it is thought that some numbers, like $196$, never produce a palindrome. A number that never forms a palindrome through the reverse and add process is called a Lychrel number. Due to the theoretical nature of these numbers, and for the purpose of this problem, we shall assume that a number is Lychrel until proven otherwise. In addition you are given that for every number below ten-thousand, it will either (i) become a palindrome in less than fifty iterations, or, (ii) no one, with all the computing power that exists, has managed so far to map it to a palindrome. In fact, $10677$ is the first number to be shown to require over fifty iterations before producing a palindrome: $4668731596684224866951378664$ ($53$ iterations, $28$-digits).
Surprisingly, there are palindromic numbers that are themselves Lychrel numbers; the first example is $4994$.
How many Lychrel numbers are there below ten-thousand?
<p class="smaller">NOTE: Wording was modified slightly on 24 April 2007 to emphasise the theoretical nature of Lychrel numbers.

## 処理速度


| 計測        | 実行回数 (b.N) | 平均実行時間 (ns/op)   |
| --------- | ---------- | ---------------- |
| わたしの回答    | 178        | 6,646,831 ns/op  |
| GPT4.1    | 99         | 11,656,687 ns/op |
| Gemini2.5 | 78         | 15,302,823 ns/op |


## GPT-4.1の回答
```go
// 文字列として反転した数値を返す
func reverseNum(n int) int {
	s := strconv.Itoa(n)
	rs := ""
	for i := len(s) - 1; i >= 0; i-- {
		rs += string(s[i])
	}
	num, _ := strconv.Atoi(rs)
	return num
}

// 回文判定
func isPalindrome(n int) bool {
	s := strconv.Itoa(n)
	for i := 0; i < len(s)/2; i++ {
		if s[i] != s[len(s)-1-i] {
			return false
		}
	}
	return true
}

// nがLychrelか判定（50回で回文にならなければtrue）
func isLychrel(n int) bool {
	num := n
	for i := 0; i < 50; i++ {
		num += reverseNum(num)
		if isPalindrome(num) {
			return false
		}
	}
	return true
}

func main() {
	count := 0
	for n := 1; n < 10000; n++ {
		if isLychrel(n) {
			count++
		}
	}
	fmt.Println(count)
}
```

## Gemini2.5 Flashの回答
```go
// isPalindrome は big.Int 型の数が回文数かどうかを判定します。
// 数を文字列に変換し、その文字列が回文であるかを確認します。
func isPalindrome(n *big.Int) bool {
	s := n.String()
	runes := []rune(s)
	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
		if runes[i] != runes[j] {
			return false
		}
	}
	return true
}

// reverse は big.Int 型の数を反転させた新しい big.Int を返します。
// 数を文字列に変換し、文字列を反転させてから、再び数に変換します。
func reverse(n *big.Int) *big.Int {
	s := n.String()
	runes := []rune(s)
	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
		runes[i], runes[j] = runes[j], runes[i]
	}
	reversedStr := string(runes)

	reversedNum := new(big.Int)
	// base 10 で文字列を big.Int に変換します
	reversedNum.SetString(reversedStr, 10)
	return reversedNum
}

// isLychrel は与えられた数がライクレル数かどうかを判定します。
// 50回の反復で回文数にならなければライクレル数とみなします。
func isLychrel(n int) bool {
	// 任意精度整数を扱うために big.Int 型に変換します
	num := big.NewInt(int64(n))

	// 最大50回の反復処理
	for i := 0; i < 50; i++ {
		reversedNum := reverse(num)
		// num = num + reversedNum
		num.Add(num, reversedNum)

		if isPalindrome(num) {
			// 回文数になったので、ライクレル数ではない
			return false
		}
	}

	// 50回反復しても回文数にならなかったため、ライクレル数とみなす
	return true
}

func solve() {
	lychrelCount := 0
	limit := 10000

	for i := 1; i < limit; i++ {
		if isLychrel(i) {
			lychrelCount++
		}
	}

	fmt.Printf("1から%d未満のライクレル数の個数: %d\n", limit, lychrelCount)
}
```
