### PR TITLE
Problem045

### DIFF
--- a/problems/045/main.go
+++ b/problems/045/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+func main() {
+	solve()
+}
+
+// 636	   1646968 ns/op
+func solve() {
+	var num int64 = 0
+	// 五角数285番目の次の条件を確認
+	var x int64 = 285
+	// 六角数の値を格納
+	result := make(map[int64]bool, math.MaxInt8)
+
+	for {
+		// 五角数
+		if condition(result, (3*x*x-x)/2) {
+			num = (3*x*x - x) / 2
+			break
+		}
+		// 六角数
+		result[2*x*x-x] = true
+		x++
+	}
+	fmt.Println(num)
+}
+
+// 対象の数字が三角数と六角数であることを確認
+func condition(result map[int64]bool, target int64) bool {
+	if v, ok := result[target]; ok {
+		if isTriangularNumber(target) {
+			return v
+		}
+	}
+	return false
+}
+
+// 三角数判定
+func isTriangularNumber(num int64) bool {
+	return (num%3 == 0) || num%9 == 1
+}

--- a/problems/045/main.go
+++ b/problems/045/main.go
@@ -9,7 +9,6 @@ func main() {
 	solve()
 }
 
-// 636	   1646968 ns/op
 func solve() {
 	var num int64 = 0
 	// 五角数285番目の次の条件を確認

--- a/problems/045/main_test.go
+++ b/problems/045/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSolve(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solve()
+	}
+}


### PR DESCRIPTION
## 問題
### [Triangular, Pentagonal, and Hexagonal](https://projecteuler.net/problem=45)

<p>Triangle, pentagonal, and hexagonal numbers are generated by the following formulae:</p>
<table><tr><td>Triangle</td>
<td> </td>
<td>$T_n=n(n+1)/2$</td>
<td> </td>
<td>$1, 3, 6, 10, 15, ...$</td>
</tr><tr><td>Pentagonal</td>
<td> </td>
<td>$P_n=n(3n - 1)/2$</td>
<td> </td>
<td>$1, 5, 12, 22, 35, ...$</td>
</tr><tr><td>Hexagonal</td>
<td> </td>
<td>$H_n=n(2n - 1)$</td>
<td> </td>
<td>$1, 6, 15, 28, 45, ...$</td>
</tr></table><p>It can be verified that $T_{285} = P_{165} = H_{143} = 40755$.</p>
<p>Find the next triangle number that is also pentagonal and hexagonal.</p>


## 処理速度

| 計測        | 実行回数 (b.N) | 平均実行時間 (ns/op)  |
| --------- | ---------- | --------------- |
| わたしの回答    | 622        | 1,675,453 ns/op |
| GPT4.1    | 969        | 1,231,545 ns/op |
| Gemini2.5 | 27361      | 44,265 ns/op    |


## GPT-4.1の回答
```go
// 五角数判定
func isPentagonal(x int64) bool {
	// n = (sqrt(24*x + 1) + 1) / 6 が整数ならOK
	// 判定用に平方根の整数値を求める
	n := (1 + isqrt(24*x+1))
	return n%6 == 0 && pentagonal(n/6) == x
}

// 整数の平方根
func isqrt(n int64) int64 {
	var x int64 = n
	var y int64 = (x + 1) / 2
	for y < x {
		x = y
		y = (x + n/x) / 2
	}
	return x
}

// 五角数
func pentagonal(n int64) int64 {
	return n * (3*n - 1) / 2
}

func solve() {
	for n := int64(144); ; n++ { // H_143以降
		hex := n * (2*n - 1)
		if isPentagonal(hex) {
			fmt.Println(hex)
			break
		}
	}
}
```

## Gemini2.5 Flashの回答
```go
func isPentagonal(x int64) bool {
	val := (1.0 + math.Sqrt(1.0+24.0*float64(x))) / 6.0
	return val == float64(int64(val))
}

func solve() {

	n := int64(144)

	for {
		h := n * (2*n - 1)
		if isPentagonal(h) {
			fmt.Println(h)
			break
		}
		n++
	}
}
```
