### PR TITLE
Add main.go for problem 041 solution

### DIFF
--- a/problems/041/main.go
+++ b/problems/041/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	solve()
+}
+
+func solve() {
+	x := 987654321
+	fmt.Println(isPandigital(x))
+	for 0 < x {
+		if isPandigital(x) && isPrimeNumber(x) {
+			fmt.Println(x)
+			return
+		}
+		x--
+	}
+}
+
+func isPrimeNumber(n int) bool {
+	x := 2
+	for x*x <= n {
+		if n%x == 0 {
+			return false
+		}
+		x++
+	}
+	return true
+}
+
+func isPandigital(n int) bool {
+	s := strconv.Itoa(n)
+	length := len(s)
+	for i := 1; i <= length; i++ {
+		if !strings.Contains(s, strconv.Itoa(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/problems/041/main_test.go
+++ b/problems/041/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func BenchmarkSolve(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solve()
+	}
+}


### PR DESCRIPTION
## 問題
### [Pandigital Prime](https://projecteuler.net/problem=41)
<p>We shall say that an $n$-digit number is pandigital if it makes use of all the digits $1$ to $n$ exactly once. For example, $2143$ is a $4$-digit pandigital and is also prime.</p>
<p>What is the largest $n$-digit pandigital prime that exists?</p>


## 処理速度

## GPT-4.1の回答
```go
// 素数判定（エラトステネスでもよいが普通に判定）
func isPrime(n int) bool {
	if n < 2 {
		return false
	}
	sqrtN := int(math.Sqrt(float64(n)))
	for i := 2; i <= sqrtN; i++ {
		if n%i == 0 {
			return false
		}
	}
	return true
}

// パンデジタル数を大きい順に全列挙（降順Perm）
func permuteDesc(nums []byte, l int, results *[]int) {
	if l == len(nums)-1 {
		num, _ := strconv.Atoi(string(nums))
		*results = append(*results, num)
		return
	}
	for i := l; i < len(nums); i++ {
		nums[l], nums[i] = nums[i], nums[l]
		permuteDesc(nums, l+1, results)
		nums[l], nums[i] = nums[i], nums[l]
	}
}

func main() {
	// パンデジタル数の桁数（9→1まで降順に試す）
	for n := 9; n >= 1; n-- {
		// 桁数nのパンデジタル数を生成
		digits := make([]byte, n)
		for i := 0; i < n; i++ {
			digits[i] = byte('1' + i)
		}
		// 大きい順に並び替え（降順Permで最大から調べるため）
		sort.Sort(sort.Reverse(sort.ByteSlice(digits)))

		var pandigitals []int
		permuteDesc(digits, 0, &pandigitals)
		sort.Sort(sort.Reverse(sort.IntSlice(pandigitals)))

		for _, num := range pandigitals {
			if isPrime(num) {
				fmt.Printf("Largest pandigital prime: %d\n", num)
				return
			}
		}
	}
}
```

## Gemini2.5 Flashの回答
```go

```
